### PR TITLE
chore(merchants): add additional MID for Linode fir SoM 2025

### DIFF
--- a/lib/yellow_pages/merchants.yaml
+++ b/lib/yellow_pages/merchants.yaml
@@ -161,7 +161,7 @@
 - network_ids: ["WUE8R8DSVX4EVFC"]
   name: Airtable
 - network_ids: ["000445120538993"] # Not sure how to categorize this
-- network_ids: ["000445496499994"]
+- network_ids: ["000445496499994", "000526375168881"]
   name: Linode
 - network_ids: ["207481000119835"]
   name: Green Mountain Power


### PR DESCRIPTION
Context: https://hackclub.slack.com/archives/C090JKDJYN8/p1756727762909569 (this is from SOM help channel)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Expanded Linode merchant coverage by supporting multiple network IDs.
- Bug Fixes
  - Removed an invalid Linode identifier and corrected the remaining IDs to improve matching accuracy.
- Chores
  - Updated merchant configuration to reflect current Linode identifiers.

These changes enhance recognition and categorization of Linode-related records, reducing mismatches and improving reliability across affected views and reports. Users should see more consistent identification of Linode without needing to take any action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->